### PR TITLE
Sets entrypoint-service for rocks

### DIFF
--- a/csi-attacher/4.5.1/rockcraft.yaml
+++ b/csi-attacher/4.5.1/rockcraft.yaml
@@ -31,9 +31,11 @@ services:
     summary: "csi-attacher service"
     override: replace
     startup: enabled
-    command: "/csi-attacher"
+    command: "/csi-attacher [ --help ]"
     on-success: shutdown
     on-failure: shutdown
+
+entrypoint-service: csi-attacher
 
 parts:
   build-csi-attacher:

--- a/csi-node-driver-registrar/2.10.0/rockcraft.yaml
+++ b/csi-node-driver-registrar/2.10.0/rockcraft.yaml
@@ -34,9 +34,11 @@ services:
     summary: "csi-node-driver-registrar service"
     override: replace
     startup: enabled
-    command: "/csi-node-driver-registrar"
+    command: "/csi-node-driver-registrar [ --help ]"
     on-success: shutdown
     on-failure: shutdown
+
+entrypoint-service: csi-node-driver-registrar
 
 parts:
   build-csi-node-driver-registrar:

--- a/csi-provisioner/4.0.0/rockcraft.yaml
+++ b/csi-provisioner/4.0.0/rockcraft.yaml
@@ -31,9 +31,11 @@ services:
     summary: "csi-provisioner service"
     override: replace
     startup: enabled
-    command: "/csi-provisioner"
+    command: "/csi-provisioner [ --help ]"
     on-success: shutdown
     on-failure: shutdown
+
+entrypoint-service: csi-provisioner
 
 parts:
   build-csi-provisioner:

--- a/csi-resizer/1.10.1/rockcraft.yaml
+++ b/csi-resizer/1.10.1/rockcraft.yaml
@@ -31,9 +31,11 @@ services:
     summary: "csi-resizer service"
     override: replace
     startup: enabled
-    command: "/csi-resizer"
+    command: "/csi-resizer [ --help ]"
     on-success: shutdown
     on-failure: shutdown
+
+entrypoint-service: csi-resizer
 
 parts:
   build-csi-resizer:

--- a/csi-snapshotter/6.3.3/rockcraft.yaml
+++ b/csi-snapshotter/6.3.3/rockcraft.yaml
@@ -26,9 +26,11 @@ services:
     summary: "csi-snapshotter service"
     override: replace
     startup: enabled
-    command: "/csi-snapshotter"
+    command: "/csi-snapshotter [ --help ]"
     on-success: shutdown
     on-failure: shutdown
+
+entrypoint-service: csi-snapshotter
 
 parts:
   build-csi-snapshotter:

--- a/livenessprobe/2.12.0/rockcraft.yaml
+++ b/livenessprobe/2.12.0/rockcraft.yaml
@@ -29,9 +29,11 @@ services:
     summary: "livenessprobe service"
     override: replace
     startup: enabled
-    command: "/livenessprobe"
+    command: "/livenessprobe [ --help ]"
     on-success: shutdown
     on-failure: shutdown
+
+entrypoint-service: livenessprobe
 
 parts:
   build-livenessprobe:

--- a/snapshot-controller/6.3.3/rockcraft.yaml
+++ b/snapshot-controller/6.3.3/rockcraft.yaml
@@ -26,9 +26,11 @@ services:
     summary: "snapshot-controller service"
     override: replace
     startup: enabled
-    command: "/snapshot-controller"
+    command: "/snapshot-controller [ --help ]"
     on-success: shutdown
     on-failure: shutdown
+
+entrypoint-service: snapshot-controller
 
 parts:
   build-snapshot-controller:


### PR DESCRIPTION
The NFS helm chart passes additional arguments to the container images, which should be passed to the binaries. For this, we need to set the entrypoint-service, so Pebble will pass the arguments to the proper service.