### PR TITLE
Removes run-user from rocks

### DIFF
--- a/csi-attacher/4.5.1/rockcraft.yaml
+++ b/csi-attacher/4.5.1/rockcraft.yaml
@@ -16,7 +16,6 @@ version: 4.5.1
 
 base: bare
 build-base: ubuntu@22.04
-run-user: _daemon_
 
 platforms:
   amd64:

--- a/csi-node-driver-registrar/2.10.0/rockcraft.yaml
+++ b/csi-node-driver-registrar/2.10.0/rockcraft.yaml
@@ -19,7 +19,6 @@ version: 2.10.0
 
 base: bare
 build-base: ubuntu@22.04
-run-user: _daemon_
 
 platforms:
   amd64:

--- a/csi-provisioner/4.0.0/rockcraft.yaml
+++ b/csi-provisioner/4.0.0/rockcraft.yaml
@@ -16,7 +16,6 @@ version: 4.0.0
 
 base: bare
 build-base: ubuntu@22.04
-run-user: _daemon_
 
 platforms:
   amd64:

--- a/csi-resizer/1.10.1/rockcraft.yaml
+++ b/csi-resizer/1.10.1/rockcraft.yaml
@@ -16,7 +16,6 @@ version: 1.10.1
 
 base: bare
 build-base: ubuntu@22.04
-run-user: _daemon_
 
 platforms:
   amd64:

--- a/csi-snapshotter/6.3.3/rockcraft.yaml
+++ b/csi-snapshotter/6.3.3/rockcraft.yaml
@@ -11,7 +11,6 @@ version: 6.3.3
 
 base: bare
 build-base: ubuntu@22.04
-run-user: _daemon_
 
 platforms:
   amd64:

--- a/livenessprobe/2.12.0/rockcraft.yaml
+++ b/livenessprobe/2.12.0/rockcraft.yaml
@@ -14,7 +14,6 @@ version: 2.12.0
 
 base: bare
 build-base: ubuntu@22.04
-run-user: _daemon_
 
 platforms:
   amd64:

--- a/snapshot-controller/6.3.3/rockcraft.yaml
+++ b/snapshot-controller/6.3.3/rockcraft.yaml
@@ -11,7 +11,6 @@ version: 6.3.3
 
 base: bare
 build-base: ubuntu@22.04
-run-user: _daemon_
 
 platforms:
   amd64:


### PR DESCRIPTION
The CSI components need to be able to connect to the unix:///csi/csi.sock file, and they cannot do that with the current user.