### PR TITLE
Adds csi-attacher 4.6.1 rock

### DIFF
--- a/csi-attacher/4.6.1/rockcraft.yaml
+++ b/csi-attacher/4.6.1/rockcraft.yaml
@@ -1,0 +1,60 @@
+# Copyright 2024 Canonical, Ltd.
+# See LICENSE file for licensing details
+
+# Based on: https://github.com/kubernetes-csi/external-attacher/blob/v4.6.1/Dockerfile
+name: csi-attacher
+summary: csi-attacher rock
+description: |
+    A rock containing csi-attacher.
+
+    The external-attacher is a sidecar container that attaches volumes to nodes
+    by calling ControllerPublish and ControllerUnpublish functions of CSI drivers.
+    It is necessary because internal Attach/Detach controller running in Kubernetes
+    controller-manager does not have any direct interfaces to CSI drivers.
+license: Apache-2.0
+version: 4.6.1
+
+base: bare
+build-base: ubuntu@22.04
+
+platforms:
+  amd64:
+  arm64:
+
+environment:
+  APP_VERSION: 4.6.1
+
+# Services to be loaded by the Pebble entrypoint.
+services:
+  csi-attacher:
+    summary: "csi-attacher service"
+    override: replace
+    startup: enabled
+    command: "/csi-attacher [ --help ]"
+    on-success: shutdown
+    on-failure: shutdown
+
+entrypoint-service: csi-attacher
+
+parts:
+  build-csi-attacher:
+    plugin: go
+    source: https://github.com/kubernetes-csi/external-attacher.git
+    source-type: git
+    source-tag: v${CRAFT_PROJECT_VERSION}
+    source-depth: 1
+    build-snaps:
+      - go/1.22/stable
+    build-environment:
+      - CGO_ENABLED: 0
+      - GOOS: linux
+      - GOARCH: $CRAFT_ARCH_BUILD_FOR
+      - VERSION: $CRAFT_PROJECT_VERSION
+      - LDFLAGS: >
+          -X main.version=${VERSION} -extldflags "-static"
+    go-buildtags:
+      - "mod=vendor"
+    go-generate:
+      - ./cmd/csi-attacher
+    organize:
+      bin/csi-attacher: ./

--- a/tests/sanity/test_csi_attacher.py
+++ b/tests/sanity/test_csi_attacher.py
@@ -3,13 +3,15 @@
 # See LICENSE file for licensing details
 #
 
+import pytest
 from k8s_test_harness.util import docker_util, env_util
 
 
-def test_csi_attacher_rock():
+@pytest.mark.parametrize("image_version", ("4.5.1", "4.6.1"))
+def test_csi_attacher_rock(image_version):
     """Test csi-attacher rock."""
     rock = env_util.get_build_meta_info_for_rock_version(
-        "csi-attacher", "4.5.1", "amd64"
+        "csi-attacher", image_version, "amd64"
     )
     image = rock.image
 


### PR DESCRIPTION
Based on the 4.5.1 rock and upstream Dockerfile. The golang version was updated. Note that l``onghornio/csi-attacher:v4.6.1`` is only a retag of the Kubernetes official image.

Updates unit test to also test the new image.