### PR TITLE
Adds csi-resizer 1.11.1 rock

### DIFF
--- a/csi-resizer/1.11.1/rockcraft.yaml
+++ b/csi-resizer/1.11.1/rockcraft.yaml
@@ -1,0 +1,60 @@
+# Copyright 2024 Canonical, Ltd.
+# See LICENSE file for licensing details
+
+# Based on: https://github.com/kubernetes-csi/external-resizer/blob/v1.11.1/Dockerfile
+name: csi-resizer
+summary: csi-resizer rock
+description: |
+    A rock containing csi-resizer.
+
+    The CSI external-resizer is a sidecar container that watches the Kubernetes API
+    server for PersistentVolumeClaim updates and triggers ControllerExpandVolume
+    operations against a CSI endpoint if user requested more storage on
+    PersistentVolumeClaim object.
+license: Apache-2.0
+version: 1.11.1
+
+base: bare
+build-base: ubuntu@22.04
+
+platforms:
+  amd64:
+  arm64:
+
+environment:
+  APP_VERSION: 1.11.1
+
+# Services to be loaded by the Pebble entrypoint.
+services:
+  csi-resizer:
+    summary: "csi-resizer service"
+    override: replace
+    startup: enabled
+    command: "/csi-resizer [ --help ]"
+    on-success: shutdown
+    on-failure: shutdown
+
+entrypoint-service: csi-resizer
+
+parts:
+  build-csi-resizer:
+    plugin: go
+    source: https://github.com/kubernetes-csi/external-resizer.git
+    source-type: git
+    source-tag: v${CRAFT_PROJECT_VERSION}
+    source-depth: 1
+    build-snaps:
+      - go/1.22/stable
+    build-environment:
+      - CGO_ENABLED: 0
+      - GOOS: linux
+      - GOARCH: $CRAFT_ARCH_BUILD_FOR
+      - VERSION: $CRAFT_PROJECT_VERSION
+      - LDFLAGS: >
+          -X main.version=${VERSION} -extldflags "-static"
+    go-buildtags:
+      - "mod=vendor"
+    go-generate:
+      - ./cmd/csi-resizer
+    organize:
+      bin/csi-resizer: ./

--- a/tests/sanity/test_csi_resizer.py
+++ b/tests/sanity/test_csi_resizer.py
@@ -3,13 +3,15 @@
 # See LICENSE file for licensing details
 #
 
+import pytest
 from k8s_test_harness.util import docker_util, env_util
 
 
-def test_csi_resizer_rock():
+@pytest.mark.parametrize("image_version", ("1.10.1", "1.11.1"))
+def test_csi_resizer_rock(image_version):
     """Test csi-resizer rock."""
     rock = env_util.get_build_meta_info_for_rock_version(
-        "csi-resizer", "1.10.1", "amd64"
+        "csi-resizer", image_version, "amd64"
     )
     image = rock.image
 


### PR DESCRIPTION
Based on the 1.11.1 rock and upstream Dockerfile. The golang version was updated. Note that ``longhornio/csi-resizer:v1.11.1`` is only a retag of the Kubernetes official image.

Updates unit test to also test the new image.