### PR TITLE
Adds csi-snapshotter 7.0.2 rock

### DIFF
--- a/csi-snapshotter/7.0.2/rockcraft.yaml
+++ b/csi-snapshotter/7.0.2/rockcraft.yaml
@@ -1,0 +1,55 @@
+# Copyright 2024 Canonical, Ltd.
+# See LICENSE file for licensing details
+
+# Based on: https://github.com/kubernetes-csi/external-snapshotter/blob/v7.0.2/cmd/csi-snapshotter/Dockerfile
+name: csi-snapshotter
+summary: csi-snapshotter rock
+description: |
+    A rock containing the CSI snapshotter.
+license: Apache-2.0
+version: 7.0.2
+
+base: bare
+build-base: ubuntu@22.04
+
+platforms:
+  amd64:
+  arm64:
+
+environment:
+  APP_VERSION: 7.0.2
+
+# Services to be loaded by the Pebble entrypoint.
+services:
+  csi-snapshotter:
+    summary: "csi-snapshotter service"
+    override: replace
+    startup: enabled
+    command: "/csi-snapshotter [ --help ]"
+    on-success: shutdown
+    on-failure: shutdown
+
+entrypoint-service: csi-snapshotter
+
+parts:
+  build-csi-snapshotter:
+    plugin: go
+    source: https://github.com/kubernetes-csi/external-snapshotter.git
+    source-type: git
+    source-tag: v${CRAFT_PROJECT_VERSION}
+    source-depth: 1
+    build-snaps:
+      - go/1.21/stable
+    build-environment:
+      - CGO_ENABLED: 0
+      - GOOS: linux
+      - GOARCH: $CRAFT_ARCH_BUILD_FOR
+      - VERSION: $CRAFT_PROJECT_VERSION
+      - LDFLAGS: >
+          -X main.version=${VERSION} -extldflags "-static"
+    go-buildtags:
+      - "mod=vendor"
+    go-generate:
+      - ./cmd/csi-snapshotter
+    organize:
+      bin/csi-snapshotter: ./

--- a/tests/sanity/test_csi_snapshotter.py
+++ b/tests/sanity/test_csi_snapshotter.py
@@ -3,13 +3,15 @@
 # See LICENSE file for licensing details
 #
 
+import pytest
 from k8s_test_harness.util import docker_util, env_util
 
 
-def test_csi_snapshotter_rock():
+@pytest.mark.parametrize("image_version", ("6.3.3", "7.0.2"))
+def test_csi_snapshotter_rock(image_version):
     """Test csi-snapshotter rock."""
     rock = env_util.get_build_meta_info_for_rock_version(
-        "csi-snapshotter", "6.3.3", "amd64"
+        "csi-snapshotter", image_version, "amd64"
     )
     image = rock.image
 


### PR DESCRIPTION
Based on the 6.3.3 rock and upstream Dockerfile. The golang version was updated. Note that ``longhornio/csi-snapshotter:v7.0.2`` is only a retag of the Kubernetes official image.

Updates unit test to also test the new image.