### PR TITLE
Adds livenessprobe 2.13.1 rock

### DIFF
--- a/livenessprobe/2.13.1/rockcraft.yaml
+++ b/livenessprobe/2.13.1/rockcraft.yaml
@@ -1,0 +1,58 @@
+# Copyright 2024 Canonical, Ltd.
+# See LICENSE file for licensing details
+
+# Based on: https://github.com/kubernetes-csi/livenessprobe/blob/v2.13.1/Dockerfile
+name: livenessprobe
+summary: livenessprobe rock
+description: |
+    A rock containing livenessprobe.
+
+    The liveness probe is a sidecar container that exposes an HTTP /healthz endpoint,
+    which serves as kubelet's livenessProbe hook to monitor health of a CSI driver.
+license: Apache-2.0
+version: 2.13.1
+
+base: bare
+build-base: ubuntu@22.04
+
+platforms:
+  amd64:
+  arm64:
+
+environment:
+  APP_VERSION: 2.13.1
+
+# Services to be loaded by the Pebble entrypoint.
+services:
+  livenessprobe:
+    summary: "livenessprobe service"
+    override: replace
+    startup: enabled
+    command: "/livenessprobe [ --help ]"
+    on-success: shutdown
+    on-failure: shutdown
+
+entrypoint-service: livenessprobe
+
+parts:
+  build-livenessprobe:
+    plugin: go
+    source: https://github.com/kubernetes-csi/livenessprobe.git
+    source-type: git
+    source-tag: v${CRAFT_PROJECT_VERSION}
+    source-depth: 1
+    build-snaps:
+      - go/1.22/stable
+    build-environment:
+      - CGO_ENABLED: 0
+      - GOOS: linux
+      - GOARCH: $CRAFT_ARCH_BUILD_FOR
+      - VERSION: $CRAFT_PROJECT_VERSION
+      - LDFLAGS: >
+          -X main.version=${VERSION} -extldflags "-static"
+    go-buildtags:
+      - "mod=vendor"
+    go-generate:
+      - ./cmd/livenessprobe
+    organize:
+      bin/livenessprobe: ./

--- a/tests/sanity/test_livenessprobe.py
+++ b/tests/sanity/test_livenessprobe.py
@@ -3,13 +3,15 @@
 # See LICENSE file for licensing details
 #
 
+import pytest
 from k8s_test_harness.util import docker_util, env_util
 
 
-def test_livenessprobe_rock():
+@pytest.mark.parametrize("image_version", ("2.12.0", "2.13.1"))
+def test_livenessprobe_rock(image_version):
     """Test livenessprobe rock."""
     rock = env_util.get_build_meta_info_for_rock_version(
-        "livenessprobe", "2.12.0", "amd64"
+        "livenessprobe", image_version, "amd64"
     )
     image = rock.image
 


### PR DESCRIPTION
Based on the 2.12.0 rock and the upstream Dockerfile. The golang version was updated. Note that ``longhornio/livenessprobe:v2.13.1`` is only a retag of the Kubernetes official image.

Updates unit test to also test the new image.