### PR TITLE
Adds csi-snapshotter 6.3.4 rock

### DIFF
--- a/csi-snapshotter/6.3.4/rockcraft.yaml
+++ b/csi-snapshotter/6.3.4/rockcraft.yaml
@@ -1,0 +1,55 @@
+# Copyright 2024 Canonical, Ltd.
+# See LICENSE file for licensing details
+
+# Based on: https://github.com/kubernetes-csi/external-snapshotter/blob/v6.3.4/cmd/csi-snapshotter/Dockerfile
+name: csi-snapshotter
+summary: csi-snapshotter rock
+description: |
+    A rock containing the CSI snapshotter.
+license: Apache-2.0
+version: 6.3.4
+
+base: bare
+build-base: ubuntu@22.04
+
+platforms:
+  amd64:
+  arm64:
+
+environment:
+  APP_VERSION: 6.3.4
+
+# Services to be loaded by the Pebble entrypoint.
+services:
+  csi-snapshotter:
+    summary: "csi-snapshotter service"
+    override: replace
+    startup: enabled
+    command: "/csi-snapshotter [ --help ]"
+    on-success: shutdown
+    on-failure: shutdown
+
+entrypoint-service: csi-snapshotter
+
+parts:
+  build-csi-snapshotter:
+    plugin: go
+    source: https://github.com/kubernetes-csi/external-snapshotter.git
+    source-type: git
+    source-tag: v${CRAFT_PROJECT_VERSION}
+    source-depth: 1
+    build-snaps:
+      - go/1.20/stable
+    build-environment:
+      - CGO_ENABLED: 0
+      - GOOS: linux
+      - GOARCH: $CRAFT_ARCH_BUILD_FOR
+      - VERSION: $CRAFT_PROJECT_VERSION
+      - LDFLAGS: >
+          -X main.version=${VERSION} -extldflags "-static"
+    go-buildtags:
+      - "mod=vendor"
+    go-generate:
+      - ./cmd/csi-snapshotter
+    organize:
+      bin/csi-snapshotter: ./

--- a/tests/sanity/test_csi_snapshotter.py
+++ b/tests/sanity/test_csi_snapshotter.py
@@ -7,7 +7,7 @@ import pytest
 from k8s_test_harness.util import docker_util, env_util
 
 
-@pytest.mark.parametrize("image_version", ("6.3.3", "7.0.2"))
+@pytest.mark.parametrize("image_version", ("6.3.3", "6.3.4", "7.0.2"))
 def test_csi_snapshotter_rock(image_version):
     """Test csi-snapshotter rock."""
     rock = env_util.get_build_meta_info_for_rock_version(


### PR DESCRIPTION
Based on the 6.3.3 rock and upstream Dockerfile. Note that ``longhornio/csi-snapshotter:v6.3.4`` is only a retag of the Kubernetes official image.

Updates unit test to also test the new image.