### PR TITLE
Adds csi-provisioner 3.6.4 rock

### DIFF
--- a/csi-provisioner/3.6.4/rockcraft.yaml
+++ b/csi-provisioner/3.6.4/rockcraft.yaml
@@ -1,0 +1,60 @@
+# Copyright 2024 Canonical, Ltd.
+# See LICENSE file for licensing details
+
+# Based on: https://github.com/kubernetes-csi/external-provisioner/blob/v3.6.4/Dockerfile
+name: csi-provisioner
+summary: csi-provisioner rock
+description: |
+    A rock containing the CSI provisioner.
+
+    The external-provisioner is a sidecar container that dynamically provisions
+    volumes by calling `CreateVolume` and `DeleteVolume` functions of CSI drivers.
+    It is necessary because internal persistent volume controller running in Kubernetes
+    `controller-manager` does not have any direct interfaces to CSI drivers.
+license: Apache-2.0
+version: 3.6.4
+
+base: bare
+build-base: ubuntu@22.04
+
+platforms:
+  amd64:
+  arm64:
+
+environment:
+  APP_VERSION: 3.6.4
+
+# Services to be loaded by the Pebble entrypoint.
+services:
+  csi-provisioner:
+    summary: "csi-provisioner service"
+    override: replace
+    startup: enabled
+    command: "/csi-provisioner [ --help ]"
+    on-success: shutdown
+    on-failure: shutdown
+
+entrypoint-service: csi-provisioner
+
+parts:
+  build-csi-provisioner:
+    plugin: go
+    source: https://github.com/kubernetes-csi/external-provisioner.git
+    source-type: git
+    source-tag: v${CRAFT_PROJECT_VERSION}
+    source-depth: 1
+    build-snaps:
+      - go/1.21/stable
+    build-environment:
+      - CGO_ENABLED: 0
+      - GOOS: linux
+      - GOARCH: $CRAFT_ARCH_BUILD_FOR
+      - VERSION: $CRAFT_PROJECT_VERSION
+      - LDFLAGS: >
+          -X main.version=${VERSION} -extldflags "-static"
+    go-buildtags:
+      - "mod=vendor"
+    go-generate:
+      - ./cmd/csi-provisioner
+    organize:
+      bin/csi-provisioner: ./

--- a/tests/sanity/test_csi_provisioner.py
+++ b/tests/sanity/test_csi_provisioner.py
@@ -7,7 +7,7 @@ import pytest
 from k8s_test_harness.util import docker_util, env_util
 
 
-@pytest.mark.parametrize("image_version", ("4.0.0", "4.0.1"))
+@pytest.mark.parametrize("image_version", ("3.6.4", "4.0.0", "4.0.1"))
 def test_csi_provisioner_rock(image_version):
     """Test csi-provisioner rock."""
     rock = env_util.get_build_meta_info_for_rock_version(


### PR DESCRIPTION
Based on the 4.0.0 rock and upstream Dockerfile. Note that ``longhornio/csi-provisioner:v3.6.4`` is only a retag of the Kubernetes official image.

Updates unit test to also test the new image.