### PR TITLE
feat: Make images FIPS compliant

### DIFF
--- a/csi-node-driver-registrar/2.10.0/rockcraft.yaml
+++ b/csi-node-driver-registrar/2.10.0/rockcraft.yaml
@@ -47,14 +47,20 @@ parts:
     source-tag: v${CRAFT_PROJECT_VERSION}
     source-depth: 1
     build-snaps:
-      - go/1.21/stable
+      - go/1.21-fips/stable
+    stage-snaps:
+      - core22/fips-updates/stable
+    stage:
+      - -bin
     build-environment:
-      - CGO_ENABLED: 0
+      - CGO_ENABLED: 1
       - GOOS: linux
       - GOARCH: $CRAFT_ARCH_BUILD_FOR
       - VERSION: $CRAFT_PROJECT_VERSION
+      - GOTOOLCHAIN: local
+      - GOEXPERIMENT: opensslcrypto
       - LDFLAGS: >
-          -X main.version=${VERSION} -extldflags "-static"
+          -X main.version=${VERSION}
     go-buildtags:
       - "mod=vendor"
     go-generate:

--- a/csi-provisioner/4.0.0/rockcraft.yaml
+++ b/csi-provisioner/4.0.0/rockcraft.yaml
@@ -44,14 +44,20 @@ parts:
     source-tag: v${CRAFT_PROJECT_VERSION}
     source-depth: 1
     build-snaps:
-      - go/1.21/stable
+      - go/1.21-fips/stable
+    stage-snaps:
+      - core22/fips-updates/stable
+    stage:
+      - -bin
     build-environment:
-      - CGO_ENABLED: 0
+      - CGO_ENABLED: 1
       - GOOS: linux
       - GOARCH: $CRAFT_ARCH_BUILD_FOR
       - VERSION: $CRAFT_PROJECT_VERSION
+      - GOTOOLCHAIN: local
+      - GOEXPERIMENT: opensslcrypto
       - LDFLAGS: >
-          -X main.version=${VERSION} -extldflags "-static"
+          -X main.version=${VERSION}
     go-buildtags:
       - "mod=vendor"
     go-generate:

--- a/csi-snapshotter/6.3.3/rockcraft.yaml
+++ b/csi-snapshotter/6.3.3/rockcraft.yaml
@@ -39,14 +39,20 @@ parts:
     source-tag: v${CRAFT_PROJECT_VERSION}
     source-depth: 1
     build-snaps:
-      - go/1.20/stable
+      - go/1.20-fips/stable
+    stage-snaps:
+      - core22/fips-updates/stable
+    stage:
+      - -bin
     build-environment:
-      - CGO_ENABLED: 0
+      - CGO_ENABLED: 1
       - GOOS: linux
       - GOARCH: $CRAFT_ARCH_BUILD_FOR
       - VERSION: $CRAFT_PROJECT_VERSION
+      - GOTOOLCHAIN: local
+      - GOEXPERIMENT: opensslcrypto
       - LDFLAGS: >
-          -X main.version=${VERSION} -extldflags "-static"
+          -X main.version=${VERSION}
     go-buildtags:
       - "mod=vendor"
     go-generate:

--- a/livenessprobe/2.12.0/rockcraft.yaml
+++ b/livenessprobe/2.12.0/rockcraft.yaml
@@ -42,14 +42,20 @@ parts:
     source-tag: v${CRAFT_PROJECT_VERSION}
     source-depth: 1
     build-snaps:
-      - go/1.21/stable
+      - go/1.21-fips/stable
+    stage-snaps:
+      - core22/fips-updates/stable
+    stage:
+      - -bin
     build-environment:
-      - CGO_ENABLED: 0
+      - CGO_ENABLED: 1
       - GOOS: linux
       - GOARCH: $CRAFT_ARCH_BUILD_FOR
       - VERSION: $CRAFT_PROJECT_VERSION
+      - GOTOOLCHAIN: local
+      - GOEXPERIMENT: opensslcrypto
       - LDFLAGS: >
-          -X main.version=${VERSION} -extldflags "-static"
+          -X main.version=${VERSION}
     go-buildtags:
       - "mod=vendor"
     go-generate:

--- a/snapshot-controller/6.3.3/rockcraft.yaml
+++ b/snapshot-controller/6.3.3/rockcraft.yaml
@@ -39,14 +39,20 @@ parts:
     source-tag: v${CRAFT_PROJECT_VERSION}
     source-depth: 1
     build-snaps:
-      - go/1.20/stable
+      - go/1.20-fips/stable
+    stage-snaps:
+      - core22/fips-updates/stable
+    stage:
+      - -bin
     build-environment:
-      - CGO_ENABLED: 0
+      - CGO_ENABLED: 1
       - GOOS: linux
       - GOARCH: $CRAFT_ARCH_BUILD_FOR
       - VERSION: $CRAFT_PROJECT_VERSION
+      - GOTOOLCHAIN: local
+      - GOEXPERIMENT: opensslcrypto
       - LDFLAGS: >
-          -X main.version=${VERSION} -extldflags "-static"
+          -X main.version=${VERSION}
     go-buildtags:
       - "mod=vendor"
     go-generate:


### PR DESCRIPTION
### Overview

This PR makes certain rocks FIPS compliant. This is inspired by https://github.com/canonical/csi-rocks/pull/26, but other rocks need to be changed as well, since we're building everything using a specific rockcraft revision.

Without this, certain rocks fail to start with a `exec /bin/pebble: no such file or directory` error. The tests on the main branch are also failing because we lack changes on certain rocks: https://github.com/canonical/csi-rocks/actions/runs/16960535073/job/48166219282

- Go channel is updated to use the one with the FIPS changes
- Uses core22 from the FIPS channel
- Provides certain environment variables for Go in order to build a FIPS-compliant binary

The other changes are also necessary since we're using a specific rockcraft revision (changed in the original PR)