### PR TITLE
ci: Include FIPS openssl in rockcraft parts, Build ARM on LXD

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -17,8 +17,7 @@ jobs:
       arch-skipping-maximize-build-space: '["arm64"]'
       platform-labels: '{"arm64": ["self-hosted", "Linux", "ARM64", "jammy"]}'
       enabled-ubuntu-pro-features: "fips-updates"
-      multipass-image: "22.04"
-      rockcraft-revisions: '{"amd64": "3494"}'
+      rockcraft-revisions: '{"amd64": "3494", "arm64": "3547"}'
     secrets:
       UBUNTU_PRO_TOKEN: ${{ secrets.UBUNTU_PRO_TOKEN }}
   run-tests:

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -21,7 +21,7 @@ jobs:
     secrets:
       UBUNTU_PRO_TOKEN: ${{ secrets.UBUNTU_PRO_TOKEN }}
   run-tests:
-    uses: canonical/k8s-workflows/.github/workflows/run_tests.yaml@tmate-session
+    uses: canonical/k8s-workflows/.github/workflows/run_tests.yaml@main
     needs: [build-and-push-arch-specifics]
     secrets: inherit
     with:

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -21,7 +21,7 @@ jobs:
     secrets:
       UBUNTU_PRO_TOKEN: ${{ secrets.UBUNTU_PRO_TOKEN }}
   run-tests:
-    uses: canonical/k8s-workflows/.github/workflows/run_tests.yaml@main
+    uses: canonical/k8s-workflows/.github/workflows/run_tests.yaml@tmate-session
     needs: [build-and-push-arch-specifics]
     secrets: inherit
     with:

--- a/csi-node-driver-registrar/2.11.1/rockcraft.yaml
+++ b/csi-node-driver-registrar/2.11.1/rockcraft.yaml
@@ -40,6 +40,11 @@ services:
 entrypoint-service: csi-node-driver-registrar
 
 parts:
+  openssl:
+    plugin: nil
+    stage-packages:
+      - openssl-fips-module-3 # a Pro only FIPS package for openssl
+      - openssl # now automatically selected from fips-preview
   build-csi-node-driver-registrar:
     plugin: go
     source: https://github.com/kubernetes-csi/node-driver-registrar.git
@@ -48,10 +53,6 @@ parts:
     source-depth: 1
     build-snaps:
       - go/1.23-fips/stable
-    stage-snaps:
-      - core22/fips-updates/stable
-    stage:
-      - -bin
     build-environment:
       - CGO_ENABLED: 1
       - GOOS: linux

--- a/csi-provisioner/5.0.2/rockcraft.yaml
+++ b/csi-provisioner/5.0.2/rockcraft.yaml
@@ -37,6 +37,11 @@ services:
 entrypoint-service: csi-provisioner
 
 parts:
+  openssl:
+    plugin: nil
+    stage-packages:
+      - openssl-fips-module-3 # a Pro only FIPS package for openssl
+      - openssl # now automatically selected from fips-preview
   build-csi-provisioner:
     plugin: go
     source: https://github.com/kubernetes-csi/external-provisioner.git
@@ -45,10 +50,6 @@ parts:
     source-depth: 1
     build-snaps:
       - go/1.23-fips/stable
-    stage-snaps:
-      - core22/fips-updates/stable
-    stage:
-      - -bin
     build-environment:
       - CGO_ENABLED: 1
       - GOOS: linux

--- a/csi-resizer/1.11.2/rockcraft.yaml
+++ b/csi-resizer/1.11.2/rockcraft.yaml
@@ -37,6 +37,11 @@ services:
 entrypoint-service: csi-resizer
 
 parts:
+  openssl:
+    plugin: nil
+    stage-packages:
+      - openssl-fips-module-3 # a Pro only FIPS package for openssl
+      - openssl # now automatically selected from fips-preview
   build-csi-resizer:
     plugin: go
     source: https://github.com/kubernetes-csi/external-resizer.git
@@ -45,10 +50,6 @@ parts:
     source-depth: 1
     build-snaps:
       - go/1.23-fips/stable
-    stage-snaps:
-      - core22/fips-updates/stable
-    stage:
-      - -bin
     build-environment:
       - CGO_ENABLED: 1
       - GOOS: linux

--- a/csi-snapshotter/8.0.2/rockcraft.yaml
+++ b/csi-snapshotter/8.0.2/rockcraft.yaml
@@ -32,6 +32,11 @@ services:
 entrypoint-service: csi-snapshotter
 
 parts:
+  openssl:
+    plugin: nil
+    stage-packages:
+      - openssl-fips-module-3 # a Pro only FIPS package for openssl
+      - openssl # now automatically selected from fips-preview
   build-csi-snapshotter:
     plugin: go
     source: https://github.com/kubernetes-csi/external-snapshotter.git
@@ -40,10 +45,6 @@ parts:
     source-depth: 1
     build-snaps:
       - go/1.23-fips/stable
-    stage-snaps:
-      - core22/fips-updates/stable
-    stage:
-      - -bin
     build-environment:
       - CGO_ENABLED: 1
       - GOOS: linux

--- a/livenessprobe/2.13.1/rockcraft.yaml
+++ b/livenessprobe/2.13.1/rockcraft.yaml
@@ -35,6 +35,11 @@ services:
 entrypoint-service: livenessprobe
 
 parts:
+  openssl:
+    plugin: nil
+    stage-packages:
+      - openssl-fips-module-3 # a Pro only FIPS package for openssl
+      - openssl # now automatically selected from fips-preview
   build-livenessprobe:
     plugin: go
     source: https://github.com/kubernetes-csi/livenessprobe.git
@@ -42,14 +47,16 @@ parts:
     source-tag: v${CRAFT_PROJECT_VERSION}
     source-depth: 1
     build-snaps:
-      - go/1.22/stable
+      - go/1.22-fips/stable
     build-environment:
-      - CGO_ENABLED: 0
+      - CGO_ENABLED: 1
       - GOOS: linux
       - GOARCH: $CRAFT_ARCH_BUILD_FOR
       - VERSION: $CRAFT_PROJECT_VERSION
+      - GOTOOLCHAIN: local
+      - GOEXPERIMENT: opensslcrypto
       - LDFLAGS: >
-          -X main.version=${VERSION} -extldflags "-static"
+          -X main.version=${VERSION}
     go-buildtags:
       - "mod=vendor"
     go-generate:

--- a/snapshot-controller/6.3.3/rockcraft.yaml
+++ b/snapshot-controller/6.3.3/rockcraft.yaml
@@ -32,6 +32,11 @@ services:
 entrypoint-service: snapshot-controller
 
 parts:
+  openssl:
+    plugin: nil
+    stage-packages:
+      - openssl-fips-module-3 # a Pro only FIPS package for openssl
+      - openssl # now automatically selected from fips-preview
   build-snapshot-controller:
     plugin: go
     source: https://github.com/kubernetes-csi/external-snapshotter.git
@@ -39,14 +44,16 @@ parts:
     source-tag: v${CRAFT_PROJECT_VERSION}
     source-depth: 1
     build-snaps:
-      - go/1.20/stable
+      - go/1.20-fips/stable
     build-environment:
-      - CGO_ENABLED: 0
+      - CGO_ENABLED: 1
       - GOOS: linux
       - GOARCH: $CRAFT_ARCH_BUILD_FOR
       - VERSION: $CRAFT_PROJECT_VERSION
+      - GOTOOLCHAIN: local
+      - GOEXPERIMENT: opensslcrypto
       - LDFLAGS: >
-          -X main.version=${VERSION} -extldflags "-static"
+          -X main.version=${VERSION}
     go-buildtags:
       - "mod=vendor"
     go-generate:

--- a/tests/integration/test_csi_driver_nfs.py
+++ b/tests/integration/test_csi_driver_nfs.py
@@ -42,11 +42,11 @@ def _clone_helm_chart_repo(
 def _get_nfsplugin_csi_helm_cmd(chart_path: pathlib.Path):
     image_tuples = [
         # (rock_name, version, helm_image_subitem)
-        ("csi-provisioner", "4.0.0", "csiProvisioner"),
-        ("livenessprobe", "2.12.0", "livenessProbe"),
-        ("csi-node-driver-registrar", "2.10.0", "nodeDriverRegistrar"),
+        ("csi-provisioner", "5.0.2", "csiProvisioner"),
+        ("livenessprobe", "2.13.1", "livenessProbe"),
+        ("csi-node-driver-registrar", "2.11.1", "nodeDriverRegistrar"),
         ("snapshot-controller", "6.3.3", "externalSnapshotter"),
-        ("csi-snapshotter", "6.3.3", "csiSnapshotter"),
+        ("csi-snapshotter", "8.0.2", "csiSnapshotter"),
     ]
 
     images = []


### PR DESCRIPTION
### Overview

This PR builds on top of https://github.com/canonical/k8s-workflows/pull/50 and discards multipass as the build environment. Also enables building FIPS-enabled rocks on ARM and only includes OpenSSL from FIPS sources rather than the full core22.