### PR TITLE
fix: update source repos to upstream kubernetes-csi

### DIFF
--- a/csi-provisioner/5.0.2/rockcraft.yaml
+++ b/csi-provisioner/5.0.2/rockcraft.yaml
@@ -45,9 +45,9 @@ parts:
   csi-provisioner:
     after: [pebble]
     plugin: go
-    source: https://github.com/canonical/external-provisioner.git
+    source: https://github.com/kubernetes-csi/external-provisioner.git
     source-type: git
-    source-tag: v${CRAFT_PROJECT_VERSION}-ck0
+    source-tag: v${CRAFT_PROJECT_VERSION}
     source-depth: 1
     override-build: |
       # NOTE: (mateo) Use Go FIPS 1.24, the project originally required

--- a/csi-resizer/1.11.2/rockcraft.yaml
+++ b/csi-resizer/1.11.2/rockcraft.yaml
@@ -45,9 +45,9 @@ parts:
   csi-resizer:
     after: [pebble]
     plugin: go
-    source: https://github.com/canonical/external-resizer.git
+    source: https://github.com/kubernetes-csi/external-resizer.git
     source-type: git
-    source-tag: v${CRAFT_PROJECT_VERSION}-ck0
+    source-tag: v${CRAFT_PROJECT_VERSION}
     source-depth: 1
     override-build: |
       # NOTE: (mateo) Use Go FIPS 1.24, the project originally required

--- a/csi-snapshotter/8.0.2/rockcraft.yaml
+++ b/csi-snapshotter/8.0.2/rockcraft.yaml
@@ -40,9 +40,9 @@ parts:
   csi-snapshotter:
     after: [pebble]
     plugin: go
-    source: https://github.com/canonical/external-snapshotter.git
+    source: https://github.com/kubernetes-csi/external-snapshotter.git
     source-type: git
-    source-tag: v${CRAFT_PROJECT_VERSION}-ck0
+    source-tag: v${CRAFT_PROJECT_VERSION}
     source-depth: 1
     override-build: |
       # NOTE: (mateo) Use Go FIPS 1.24, the project originally required


### PR DESCRIPTION
## Overview
Change source repositories from canonical forks to upstream kubernetes-csi:
- csi-provisioner/5.0.2: canonical/external-provisioner -> kubernetes-csi/external-provisioner
- csi-resizer/1.11.2: canonical/external-resizer -> kubernetes-csi/external-resizer
- csi-snapshotter/8.0.2: canonical/external-snapshotter -> kubernetes-csi/external-snapshotter

Also remove -ck0 suffix from source tags.